### PR TITLE
Update MimicTurtleRenderTrick.kt to fix mimic beacon rendering crash.

### DIFF
--- a/projects/core/src/main/kotlin/site/siredvin/turtlematic/client/MimicTurtleRenderTrick.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/turtlematic/client/MimicTurtleRenderTrick.kt
@@ -55,11 +55,11 @@ object MimicTurtleRenderTrick : TurtleRenderTrick {
                     DataStorageObjects.MimicExtraData[upgradeData] ?: emptyCompoundTag,
                 ),
             )
-            // Yep, this is check for SAME OBJECT
+            // Yep, this is a check for SAME OBJECT
             if (entity !== dummyBlockEntity) {
                 entity.level = turtle.level
                 minecraft.blockEntityRenderDispatcher.render(entity, partialTicks, transform, buffers)
-                entity.level = null
+                // entity.level = null; Setting this to null causes a crash when rendering a beacon.
             }
         }
     }


### PR DESCRIPTION
When the level is null a beacon entity will crash the game if they are rendered. This simply just doesn't make the level null when a mimic mimics a block.