### PR TITLE
Use block center for sucking items and use same radius as scanning does

### DIFF
--- a/projects/core/src/main/kotlin/site/siredvin/turtlematic/computercraft/plugins/AutomataItemSuckPlugin.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/turtlematic/computercraft/plugins/AutomataItemSuckPlugin.kt
@@ -9,6 +9,7 @@ import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.item.ItemEntity
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.phys.AABB
+import site.siredvin.broccolium.modules.base.util.world.ScanUtils
 import site.siredvin.turtlematic.computercraft.operations.SingleOperation
 import site.siredvin.turtlematic.computercraft.peripheral.automatas.BaseAutomataCorePeripheral
 import site.siredvin.tweakium.modules.peripheral.api.IPeripheralFunction
@@ -22,18 +23,8 @@ class AutomataItemSuckPlugin(automataCore: BaseAutomataCorePeripheral) : Automat
         get() = listOf(SingleOperation.SUCK)
 
     protected fun getBox(pos: BlockPos): AABB {
-        val x: Int = pos.x
-        val y: Int = pos.y
-        val z: Int = pos.z
         val interactionRadius = automataCore.interactionRadius
-        return AABB(
-            (x - interactionRadius).toDouble(),
-            (y - interactionRadius).toDouble(),
-            (z - interactionRadius).toDouble(),
-            (x + interactionRadius).toDouble(),
-            (y + interactionRadius).toDouble(),
-            (z + interactionRadius).toDouble(),
-        )
+        return ScanUtils.getBox(pos, interactionRadius.toDouble())
     }
 
     protected val items: List<ItemEntity>


### PR DESCRIPTION
This PR depends on the PR submitted to [Minecraft-Modding-Libs/pull/2](https://github.com/SirEdvin/Minecraft-Modding-Libs/pull/2) to be merged since it depends on using the same static AABB function for scanning / sucking parity

fixes https://github.com/SirEdvin/Turtlematic/issues/34

before and after:
<img width="2560" height="1377" alt="image" src="https://github.com/user-attachments/assets/e80f8688-4395-4f05-8490-48e50e5062bb" />